### PR TITLE
fix: resolve npm run dev errors for local development

### DIFF
--- a/ca-api-golden-demo/client/src/react-app-env.d.ts
+++ b/ca-api-golden-demo/client/src/react-app-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="react-scripts" />

--- a/ca-api-golden-demo/client/tsconfig.json
+++ b/ca-api-golden-demo/client/tsconfig.json
@@ -2,7 +2,11 @@
   "compilerOptions": {
     "target": "es5",
     "module": "esnext",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "jsx": "react-jsx",
     "baseUrl": "./src",
     "strict": true,
@@ -13,8 +17,16 @@
     "isolatedModules": true,
     "noEmit": true,
     "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "allowJs": true,
+    "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules", "build"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules",
+    "build"
+  ]
 }


### PR DESCRIPTION
## Summary
- Fix ENOENT error when running `npm run dev` in development mode
- Update server to only serve static files in production mode
- Add TypeScript configuration for react-scripts compatibility

## Changes
1. **server/index.ts**: Add environment check to conditionally serve static files only in production
2. **client/tsconfig.json**: Add `allowJs` and `noFallthroughCasesInSwitch` compiler options
3. **client/src/react-app-env.d.ts**: Add TypeScript declaration file for react-scripts

## Test plan
- [x] Run `npm run dev` successfully without ENOENT errors
- [x] Verify backend API runs on port 8081
- [x] Verify React dev server runs on port 3000
- [x] Confirm API endpoints are accessible

## Notes
Local developers need to add `DANGEROUSLY_DISABLE_HOST_CHECK=true` to `client/.env` to bypass webpack dev server host validation (not included in this PR as .env files are gitignored).