### PR TITLE
Add import/export CLI scripts for YAML test suite management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__
 .env
 *.txt
+*.egg-info/

--- a/ca-agent-ops-prism/scripts/export_suite.py
+++ b/ca-agent-ops-prism/scripts/export_suite.py
@@ -1,0 +1,110 @@
+"""Export a Prism test suite to the bulk-import YAML format.
+
+Usage:
+    uv run python scripts/export_suite.py <suite_id> [output.yaml]
+    uv run python scripts/export_suite.py --list
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import psycopg2
+import psycopg2.extras
+import yaml
+
+DB_URL = os.environ.get(
+    "DATABASE_URL", "postgresql://ben:mysecretpassword@localhost:5432/prism"
+)
+
+# DB stores Python enum NAMES; bulk-import YAML uses the enum VALUES.
+# Mapping comes from src/prism/common/schemas/assertion.py::AssertionType.
+TYPE_MAP = {
+    "DATA_CHECK_ROW": "data-check-row",
+    "DATA_CHECK_ROW_COUNT": "data-check-row-count",
+    "QUERY_CONTAINS": "query-contains",
+    "TEXT_CONTAINS": "text-contains",
+    "CHART_CHECK_TYPE": "chart-check-type",
+    "DURATION_MAX_MS": "duration-max-ms",
+    "LATENCY_MAX_MS": "latency-max-ms",
+    "LOOKER_QUERY_MATCH": "looker-query-match",
+    "AI_JUDGE": "ai-judge",
+}
+
+
+def connect():
+    return psycopg2.connect(DB_URL, cursor_factory=psycopg2.extras.RealDictCursor)
+
+
+def list_suites() -> None:
+    with connect() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, name, (SELECT COUNT(*) FROM examples e "
+            "WHERE e.test_suite_id = ts.id AND NOT e.is_archived) AS n "
+            "FROM test_suites ts WHERE NOT is_archived ORDER BY id;"
+        )
+        for row in cur.fetchall():
+            print(f"  {row['id']:>3}  {row['name']:<30}  {row['n']} cases")
+
+
+def export_suite(suite_id: int) -> list[dict]:
+    with connect() as conn, conn.cursor() as cur:
+        cur.execute("SELECT name FROM test_suites WHERE id = %s;", (suite_id,))
+        suite = cur.fetchone()
+        if suite is None:
+            sys.exit(f"Suite {suite_id} not found")
+
+        cur.execute(
+            "SELECT id, question FROM examples "
+            "WHERE test_suite_id = %s AND NOT is_archived ORDER BY id;",
+            (suite_id,),
+        )
+        examples = cur.fetchall()
+
+        cur.execute(
+            "SELECT example_id, type::text AS type, weight, params FROM assertions "
+            "WHERE example_id = ANY(%s) AND NOT is_archived ORDER BY id;",
+            ([e["id"] for e in examples],),
+        )
+        asserts_by_example: dict[int, list[dict]] = {}
+        for a in cur.fetchall():
+            entry: dict = {"type": TYPE_MAP.get(a["type"], a["type"])}
+            if a["weight"] != 1.0:
+                entry["weight"] = a["weight"]
+            params = dict(a["params"] or {})
+            # Strip internal wrapper fields not accepted by the bulk-import schema.
+            params.pop("original_assertion_id", None)
+            params.pop("reasoning", None)
+            # looker-query-match keeps a `params:` key; other types inline `value`/`columns`.
+            for k, v in params.items():
+                entry[k] = v
+            asserts_by_example.setdefault(a["example_id"], []).append(entry)
+
+        return [
+            {"question": e["question"], "assertions": asserts_by_example.get(e["id"], [])}
+            for e in examples
+        ]
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] == "--list":
+        list_suites()
+        return
+
+    suite_id = int(sys.argv[1])
+    output_path = Path(sys.argv[2]) if len(sys.argv) > 2 else None
+
+    data = export_suite(suite_id)
+    yaml_str = yaml.safe_dump(data, sort_keys=False, default_flow_style=False, width=120)
+
+    if output_path:
+        output_path.write_text(yaml_str)
+        print(f"Wrote {len(data)} cases to {output_path}")
+    else:
+        print(yaml_str)
+
+
+if __name__ == "__main__":
+    main()

--- a/ca-agent-ops-prism/scripts/import_suites.py
+++ b/ca-agent-ops-prism/scripts/import_suites.py
@@ -1,0 +1,173 @@
+"""Import YAML test suite definitions into Prism.
+
+Each YAML file becomes one Prism suite named after the file stem. Existing
+questions in that suite are fully replaced — assertions included — so the
+file is always the source of truth.
+
+Usage:
+    uv run python scripts/import_suites.py <yaml_file_or_dir>
+    uv run python scripts/import_suites.py <yaml_file_or_dir> --dry-run
+    uv run python scripts/import_suites.py --list
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import psycopg2
+import psycopg2.extras
+import yaml
+
+DB_URL = os.environ.get(
+    "DATABASE_URL", "postgresql://ben:mysecretpassword@localhost:5432/prism"
+)
+
+# YAML assertion type values → PostgreSQL assertiontype enum labels.
+# Inverse of the mapping in export_suite.py.
+TYPE_MAP: dict[str, str] = {
+    "data-check-row": "DATA_CHECK_ROW",
+    "data-check-row-count": "DATA_CHECK_ROW_COUNT",
+    "query-contains": "QUERY_CONTAINS",
+    "text-contains": "TEXT_CONTAINS",
+    "chart-check-type": "CHART_CHECK_TYPE",
+    "duration-max-ms": "DURATION_MAX_MS",
+    "latency-max-ms": "LATENCY_MAX_MS",
+    "looker-query-match": "LOOKER_QUERY_MATCH",
+    "ai-judge": "AI_JUDGE",
+}
+
+
+def connect() -> psycopg2.extensions.connection:
+    return psycopg2.connect(DB_URL, cursor_factory=psycopg2.extras.RealDictCursor)
+
+
+def cmd_list() -> None:
+    with connect() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT id, name, "
+            "(SELECT COUNT(*) FROM examples e "
+            " WHERE e.test_suite_id = ts.id AND NOT e.is_archived) AS n "
+            "FROM test_suites ts WHERE NOT is_archived ORDER BY id;"
+        )
+        rows = cur.fetchall()
+    if not rows:
+        print("No suites found.")
+        return
+    for row in rows:
+        print(f"  {row['id']:>3}  {row['name']:<40}  {row['n']} questions")
+
+
+def _import_file(cur, path: Path, dry_run: bool) -> tuple[str, int, str]:
+    """Import one YAML file. Returns (suite_name, question_count, action)."""
+    with open(path) as f:
+        cases = yaml.safe_load(f)
+
+    if not cases:
+        return path.stem, 0, "skipped (empty)"
+
+    suite_name = path.stem
+
+    cur.execute(
+        "SELECT id FROM test_suites WHERE name = %s AND NOT is_archived;",
+        (suite_name,),
+    )
+    row = cur.fetchone()
+
+    if row:
+        suite_id = row["id"]
+        action = "updated"
+    else:
+        suite_id = None
+        action = "created"
+
+    if dry_run:
+        return suite_name, len(cases), f"dry-run ({action})"
+
+    if suite_id is None:
+        cur.execute(
+            "INSERT INTO test_suites (name, tags, is_archived) VALUES (%s, %s, false) RETURNING id;",
+            (suite_name, json.dumps({})),
+        )
+        suite_id = cur.fetchone()["id"]
+    else:
+        # Full replace: delete assertions then examples for this suite.
+        cur.execute(
+            "DELETE FROM assertions WHERE example_id IN "
+            "(SELECT id FROM examples WHERE test_suite_id = %s);",
+            (suite_id,),
+        )
+        cur.execute(
+            "DELETE FROM examples WHERE test_suite_id = %s;",
+            (suite_id,),
+        )
+
+    for case in cases:
+        cur.execute(
+            "INSERT INTO examples (test_suite_id, logical_id, question, is_archived) "
+            "VALUES (%s, %s, %s, false) RETURNING id;",
+            (suite_id, str(uuid.uuid4()), case["question"]),
+        )
+        example_id = cur.fetchone()["id"]
+
+        for a in case.get("asserts", []):
+            db_type = TYPE_MAP.get(a["type"])
+            if db_type is None:
+                print(
+                    f"  WARNING: unknown assertion type '{a['type']}' in "
+                    f"{path.name} — skipping",
+                    file=sys.stderr,
+                )
+                continue
+            weight = a.get("weight", 1.0)
+            params = {k: v for k, v in a.items() if k not in ("type", "weight")}
+            cur.execute(
+                "INSERT INTO assertions (example_id, type, weight, params, is_archived) "
+                "VALUES (%s, %s::assertiontype, %s, %s, false);",
+                (example_id, db_type, weight, json.dumps(params)),
+            )
+
+    return suite_name, len(cases), action
+
+
+def cmd_import(path: Path, dry_run: bool) -> None:
+    yaml_files = [path] if path.is_file() else sorted(path.rglob("*.yaml"))
+
+    if not yaml_files:
+        sys.exit(f"No YAML files found at {path}")
+
+    with connect() as conn:
+        with conn.cursor() as cur:
+            for yaml_file in yaml_files:
+                try:
+                    name, count, action = _import_file(cur, yaml_file, dry_run)
+                    print(f"  {action}: {name} ({count} questions)")
+                except Exception as exc:  # pylint: disable=broad-except
+                    print(f"  ERROR: {yaml_file.name}: {exc}", file=sys.stderr)
+                    raise
+        if not dry_run:
+            conn.commit()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Import YAML test suites into Prism (full replace per file)."
+    )
+    parser.add_argument("path", nargs="?", help="YAML file or directory of YAML files")
+    parser.add_argument("--list", action="store_true", help="List existing suites and exit")
+    parser.add_argument("--dry-run", action="store_true", help="Validate without writing to DB")
+    args = parser.parse_args()
+
+    if args.list or args.path is None:
+        cmd_list()
+        return
+
+    cmd_import(Path(args.path), dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/ca-agent-ops-prism/scripts/import_suites.py
+++ b/ca-agent-ops-prism/scripts/import_suites.py
@@ -65,12 +65,21 @@ def cmd_list() -> None:
 def _import_file(cur, path: Path, dry_run: bool) -> tuple[str, int, str]:
     """Import one YAML file. Returns (suite_name, question_count, action)."""
     with open(path) as f:
-        cases = yaml.safe_load(f)
+        data = yaml.safe_load(f)
 
-    if not cases:
+    if not data:
         return path.stem, 0, "skipped (empty)"
 
-    suite_name = path.stem
+    # Support both the legacy bare-list format and the new {label, cases} mapping.
+    if isinstance(data, list):
+        suite_name = path.stem
+        cases = data
+    else:
+        suite_name = data.get("label") or path.stem
+        cases = data.get("cases") or []
+
+    if not cases:
+        return suite_name, 0, "skipped (no cases)"
 
     cur.execute(
         "SELECT id FROM test_suites WHERE name = %s AND NOT is_archived;",

--- a/ca-agent-ops-prism/scripts/import_suites.py
+++ b/ca-agent-ops-prism/scripts/import_suites.py
@@ -123,7 +123,7 @@ def _import_file(cur, path: Path, dry_run: bool) -> tuple[str, int, str]:
         )
         example_id = cur.fetchone()["id"]
 
-        for a in case.get("asserts", []):
+        for a in case.get("assertions", case.get("asserts", [])):
             db_type = TYPE_MAP.get(a["type"])
             if db_type is None:
                 print(

--- a/ca-agent-ops-prism/src/prism/server/clients/gen_ai_client.py
+++ b/ca-agent-ops-prism/src/prism/server/clients/gen_ai_client.py
@@ -22,7 +22,7 @@ from google.genai import types
 import pydantic
 
 # Default model configuration
-DEFAULT_MODEL = "gemini-2.5-pro"
+DEFAULT_MODEL = "gemini-3-flash-preview"
 
 ResponseSchema = TypeVar("ResponseSchema", bound=pydantic.BaseModel)
 

--- a/ca-agent-ops-prism/src/prism/server/clients/gen_ai_client.py
+++ b/ca-agent-ops-prism/src/prism/server/clients/gen_ai_client.py
@@ -22,7 +22,7 @@ from google.genai import types
 import pydantic
 
 # Default model configuration
-DEFAULT_MODEL = "gemini-3-flash-preview"
+DEFAULT_MODEL = "gemini-2.5-flash"
 
 ResponseSchema = TypeVar("ResponseSchema", bound=pydantic.BaseModel)
 


### PR DESCRIPTION
## Summary

- **`ca-agent-ops-prism/scripts/import_suites.py`** — CLI to sync YAML test suite definitions into Prism's Postgres DB. Supports the `{label, cases}` mapping format (human-readable suite names) as well as the legacy bare-list format. Does a full replace per suite so the YAML file is always the source of truth. Includes `--list` and `--dry-run` flags.
- **`ca-agent-ops-prism/scripts/export_suite.py`** — CLI to export an existing Prism suite back to the bulk-import YAML format, useful for round-tripping and seeding version-controlled YAML files from suites created in the UI.
- **Default AI Judge model changed to `gemini-2.5-flash`** — `gemini-2.5-pro` was hitting `RESOURCE_EXHAUSTED` (429) errors under load. `gemini-2.5-flash` has a higher default quota and is GA.

## Motivation

When maintaining test suites alongside LookML in a separate repo, it's useful to drive Prism from version-controlled YAML files rather than managing questions only through the UI. These scripts let you keep YAML as the source of truth and re-sync into Prism on demand (e.g. as part of a CI step or a post-merge hook).

## Test plan

- [ ] `uv run python scripts/import_suites.py path/to/suite.yaml` creates suite and questions in Prism DB
- [ ] Re-running the import replaces existing questions without duplicating the suite
- [ ] `uv run python scripts/import_suites.py --dry-run path/to/suite.yaml` validates without writing
- [ ] `uv run python scripts/export_suite.py <suite_id>` produces valid YAML that can be re-imported
- [ ] AI Judge assertions complete without 429 errors on `gemini-2.5-flash`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)